### PR TITLE
Add missing types from atom-languageclient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix atom-package-deps issues (#60)
 -
+
 ### 2.3.4
 
 - Fix copying from overlays on MacOS (#58)

--- a/types-packages/busy-signal.d.ts
+++ b/types-packages/busy-signal.d.ts
@@ -1,24 +1,27 @@
+import type { IdeUri } from "./uri"
+
 export interface BusySignalOptions {
   /**
    * Can say that a busy signal will only appear when a given file is open.
    * Default = `null`, meaning the busy signal applies to all files.
    */
-  onlyForFile?: string
+  onlyForFile?: IdeUri
 
   /**
    * Is user waiting for computer to finish a task? (traditional busy spinner)
    * or is the computer waiting for user to finish a task? (action required)
-   * Default = `"computer"`.
+   * @defaultValue `'computer'`
    */
   waitingFor?: "computer" | "user"
 
   /**
-   * Debounce it? default = `true` for busy-signal, and false for action-required.
+   * Debounce it? default = `true` for busy-signal, and `false` for action-required.
    */
   debounce?: boolean
 
   /**
-   * If `onClick` is set, then the tooltip will be clickable. Default = `null`.
+   * If `onClick` is set, then the tooltip will be clickable.
+   * @defaultValue `null`
    */
   onDidClick?: () => void
 

--- a/types-packages/code-actions.d.ts
+++ b/types-packages/code-actions.d.ts
@@ -1,5 +1,16 @@
 import * as Atom from "atom"
 import { Message } from "atom/linter"
+// TODO add code action support to Atom linter?
+
+export type DiagnosticType = "Error" | "Warning" | "Info"
+
+export interface Diagnostic {
+  providerName: string
+  type: DiagnosticType
+  filePath: string
+  text?: string
+  range: Atom.Range
+}
 
 export interface CodeAction {
   apply(): Promise<void>
@@ -13,7 +24,7 @@ export interface CodeActionProvider {
   getCodeActions(
     editor: Atom.TextEditor,
     range: Atom.Range,
-    diagnostics: Message[]
+    diagnostics: Diagnostic[] // | Message[]
   ): Promise<CodeAction[] | null | undefined>
 }
 
@@ -24,5 +35,5 @@ export interface CodeActionProvider {
  * extended to provide a stream of CodeActions based on the cursor position.
  */
 export interface CodeActionFetcher {
-  getCodeActionForDiagnostic: (diagnostic: Message, editor: Atom.TextEditor) => Promise<CodeAction[]>
+  getCodeActionForDiagnostic: (diagnostic: Diagnostic /* | Message */, editor: Atom.TextEditor) => Promise<CodeAction[]>
 }

--- a/types-packages/code-format.d.ts
+++ b/types-packages/code-format.d.ts
@@ -1,0 +1,26 @@
+import type { TextEditor, Point, Range } from "atom"
+import type { TextEdit } from "./text-edit"
+
+export interface FileCodeFormatProvider {
+  formatEntireFile: (editor: TextEditor, range: Range) => Promise<TextEdit[]>
+  priority: number
+  grammarScopes: string[]
+}
+
+export interface RangeCodeFormatProvider {
+  formatCode: (editor: TextEditor, range: Range) => Promise<TextEdit[]>
+  priority: number
+  grammarScopes: string[]
+}
+
+export interface OnSaveCodeFormatProvider {
+  formatOnSave: (editor: TextEditor) => Promise<TextEdit[]>
+  priority: number
+  grammarScopes: string[]
+}
+
+export interface OnTypeCodeFormatProvider {
+  formatAtPosition: (editor: TextEditor, position: Point, character: string) => Promise<TextEdit[]>
+  priority: number
+  grammarScopes: string[]
+}

--- a/types-packages/console.d.ts
+++ b/types-packages/console.d.ts
@@ -1,0 +1,34 @@
+export interface SourceInfo {
+  id: string
+  name: string
+  start?: () => void
+  stop?: () => void
+}
+
+export type ConsoleService = (options: SourceInfo) => ConsoleApi
+
+export interface ConsoleApi {
+  setStatus(status: OutputProviderStatus): void
+  append(message: Message): void
+  dispose(): void
+  log(object: string): void
+  error(object: string): void
+  warn(object: string): void
+  info(object: string): void
+}
+
+export type OutputProviderStatus = "starting" | "running" | "stopped"
+
+export interface Message {
+  text: string
+  level: Level
+  tags?: string[] | null
+  kind?: MessageKind | null
+  scopeName?: string | null
+}
+
+export type TaskLevelType = "info" | "log" | "warning" | "error" | "debug" | "success"
+export type Level = TaskLevelType | Color
+type Color = "red" | "orange" | "yellow" | "green" | "blue" | "purple" | "violet" | "rainbow"
+
+export type MessageKind = "message" | "request" | "response"

--- a/types-packages/datatip.d.ts
+++ b/types-packages/datatip.d.ts
@@ -27,7 +27,17 @@ export interface DatatipProvider {
    * It is recommended that it be the name of the provider's package.
    */
   providerName: string
-  datatip(editor: Atom.TextEditor, bufferPosition: Atom.Point): Promise<Datatip | undefined | null>
+  datatip(
+    editor: Atom.TextEditor,
+    bufferPosition: Atom.Point
+    /**
+     * The mouse event that triggered the datatip.
+     * This is null for manually toggled datatips.
+     */,
+    mouseEvent?: MouseEvent | null
+  ): Promise<Datatip | undefined | null>
+
+  validForScope(scopeName: string): boolean // should be optional?
 }
 
 export interface ModifierDatatipProvider {

--- a/types-packages/datatip.d.ts
+++ b/types-packages/datatip.d.ts
@@ -21,7 +21,7 @@ export type PinnedDatatipPosition = "end-of-line" | "above-range"
 
 export interface DatatipProvider {
   priority: number
-  grammarScopes?: ReadonlyArray<string>
+
   /**
    * A unique name for the provider to be used for analytics.
    * It is recommended that it be the name of the provider's package.
@@ -37,7 +37,11 @@ export interface DatatipProvider {
     mouseEvent?: MouseEvent | null
   ): Promise<Datatip | undefined | null>
 
-  validForScope(scopeName: string): boolean // should be optional?
+  /** Either pass this or `validForScope` */
+  grammarScopes?: ReadonlyArray<string>
+
+  /** Either pass `grammarScopes` or this function. */
+  validForScope?(scopeName: string): boolean
 }
 
 export interface ModifierDatatipProvider {

--- a/types-packages/datatip.d.ts
+++ b/types-packages/datatip.d.ts
@@ -29,11 +29,11 @@ export interface DatatipProvider {
   providerName: string
   datatip(
     editor: Atom.TextEditor,
-    bufferPosition: Atom.Point
+    bufferPosition: Atom.Point,
     /**
      * The mouse event that triggered the datatip.
      * This is null for manually toggled datatips.
-     */,
+     */
     mouseEvent?: MouseEvent | null
   ): Promise<Datatip | undefined | null>
 

--- a/types-packages/definitions.d.ts
+++ b/types-packages/definitions.d.ts
@@ -48,6 +48,7 @@ export interface DefinitionQueryResult {
  * Provides definitions for a set of language grammars.
  */
 export interface DefinitionProvider {
+  name: string
   /**
    * If there are multiple providers for a given grammar,
    * the one with the highest priority will be used.

--- a/types-packages/definitions.d.ts
+++ b/types-packages/definitions.d.ts
@@ -1,10 +1,12 @@
 import * as Atom from "atom"
 
+export type IdeUri = string
+
 export interface Definition {
   /**
    * Path of the file in which the definition is located.
    */
-  path: string
+  path: IdeUri
   /**
    * First character of the definition's identifier.
    * e.g. "F" in `class Foo {}`
@@ -23,7 +25,7 @@ export interface Definition {
   /**
    * If provided, `projectRoot` will be used to display a relativized version of `path`.
    */
-  projectRoot?: string
+  projectRoot?: IdeUri
   /**
    * `language` may be used by consumers to identify the source of definitions.
    */

--- a/types-packages/definitions.d.ts
+++ b/types-packages/definitions.d.ts
@@ -1,6 +1,5 @@
 import * as Atom from "atom"
-
-export type IdeUri = string
+import { IdeUri } from "./uri"
 
 export interface Definition {
   /**

--- a/types-packages/find-references.d.ts
+++ b/types-packages/find-references.d.ts
@@ -5,7 +5,7 @@ export interface FindReferencesProvider {
   /**
    * Return true if your provider supports finding references for the provided Atom.TextEditor.
    */
-  isEditorSupported(editor: Atom.TextEditor): boolean | Promise<boolean>;
+  isEditorSupported(editor: Atom.TextEditor): boolean | Promise<boolean>
 
   /**
    * `findReferences` will only be called if `isEditorSupported` previously returned true

--- a/types-packages/find-references.d.ts
+++ b/types-packages/find-references.d.ts
@@ -1,4 +1,5 @@
 import * as Atom from "atom"
+import { IdeUri } from "./uri"
 
 export interface FindReferencesProvider {
   /**
@@ -15,9 +16,9 @@ export interface FindReferencesProvider {
 
 export interface Reference {
   /**
-   * Nuclide URI of the file path
+   * URI of the file path
    */
-  uri: string
+  uri: IdeUri
   /**
    * name of calling method/function/symbol
    */
@@ -27,7 +28,7 @@ export interface Reference {
 
 export interface FindReferencesData {
   type: "data"
-  baseUri: string
+  baseUri: IdeUri
   referencedSymbolName: string
   references: Reference[]
   /**

--- a/types-packages/find-references.d.ts
+++ b/types-packages/find-references.d.ts
@@ -4,7 +4,7 @@ export interface FindReferencesProvider {
   /**
    * Return true if your provider supports finding references for the provided Atom.TextEditor.
    */
-  isEditorSupported(editor: Atom.TextEditor): Promise<boolean>
+  isEditorSupported(editor: Atom.TextEditor): boolean | Promise<boolean>;
 
   /**
    * `findReferences` will only be called if `isEditorSupported` previously returned true

--- a/types-packages/main.d.ts
+++ b/types-packages/main.d.ts
@@ -13,6 +13,8 @@ export * from "./hyperclick"
 export * from "./outline"
 export * from "./sig-help"
 export * from "./markdown-service"
+export * from "./code-format"
+export * from "./text-edit"
 
 import { BusySignalProvider } from "./busy-signal.d"
 import { CodeActionProvider } from "./code-actions"

--- a/types-packages/main.d.ts
+++ b/types-packages/main.d.ts
@@ -3,6 +3,7 @@
  * @see https://github.com/atom-ide-community/atom-ide-base
  */
 
+export * from "./uri"
 export * from "./busy-signal"
 export * from "./code-actions"
 export * from "./code-highlight"

--- a/types-packages/main.d.ts
+++ b/types-packages/main.d.ts
@@ -15,6 +15,7 @@ export * from "./sig-help"
 export * from "./markdown-service"
 export * from "./code-format"
 export * from "./text-edit"
+export * from "./refactor"
 
 import { BusySignalProvider } from "./busy-signal.d"
 import { CodeActionProvider } from "./code-actions"

--- a/types-packages/main.d.ts
+++ b/types-packages/main.d.ts
@@ -16,6 +16,7 @@ export * from "./markdown-service"
 export * from "./code-format"
 export * from "./text-edit"
 export * from "./refactor"
+export * from "./console"
 
 import { BusySignalProvider } from "./busy-signal.d"
 import { CodeActionProvider } from "./code-actions"

--- a/types-packages/outline.d.ts
+++ b/types-packages/outline.d.ts
@@ -14,7 +14,7 @@ export interface OutlineProvider {
 
 export interface OutlineTree {
   /**
-   * from Atom.Octicon (that type's not allowed over rpc so we use string)
+   * from Atom.Octicon or Atom.OcticonsPrivate (types not allowed over rpc so we use string)
    */
   icon?: string
   /**
@@ -23,9 +23,12 @@ export interface OutlineTree {
   kind?: OutlineTreeKind
 
   /**
-   * Must be one or the other. If both are present, tokenizedText is preferred.
+   * Must have `plainText` or the `tokenizedText` property. If both are present, `tokenizedText` is preferred.
    */
   plainText?: string
+  /**
+   * Must have `plainText` or the `tokenizedText` property. If both are present, `tokenizedText` is preferred.
+   */
   tokenizedText?: TokenizedText
 
   /**

--- a/types-packages/refactor.d.ts
+++ b/types-packages/refactor.d.ts
@@ -1,0 +1,9 @@
+import type { TextEditor, Point } from "atom"
+import type { TextEdit } from "./text-edit"
+import type { IdeUri } from "./uri"
+
+export interface RefactorProvider {
+  grammarScopes: string[]
+  priority: number
+  rename?(editor: TextEditor, position: Point, newName: string): Promise<Map<IdeUri, TextEdit[]> | null>
+}

--- a/types-packages/sig-help.d.ts
+++ b/types-packages/sig-help.d.ts
@@ -2,10 +2,27 @@ import { DisposableLike, Point, TextEditor } from "atom"
 
 export type SignatureHelpRegistry = (provider: SignatureHelpProvider) => DisposableLike
 
+/**
+ * Signature help is activated when:
+ * - upon keystroke, any provider with a matching grammar scope contains
+ *   the pressed key inside its triggerCharacters set
+ * - the signature-help:show command is manually activated
+ *
+ * Once signature help has been triggered, the provider will be queried immediately
+ * with the current cursor position, and then repeatedly upon cursor movements
+ * until a null/empty signature is returned.
+ *
+ * Returned signatures will be displayed in a small datatip at the current cursor.
+ * The highest-priority provider with a non-null result will be used.
+ */
 export interface SignatureHelpProvider {
   priority: number
   grammarScopes: ReadonlyArray<string>
 
+  /**
+   * A set of characters that will trigger signature help when typed.
+   * If a null/empty set is provided, only manual activation of the command works.
+   */
   triggerCharacters?: Set<string>
 
   getSignatureHelp(editor: TextEditor, point: Point): Promise<SignatureHelp | undefined | null>
@@ -13,17 +30,26 @@ export interface SignatureHelpProvider {
 
 export interface SignatureHelp {
   signatures: Signature[]
-  activeSignature?: number
-  activeParameter?: number
+  activeSignature?: number | null
+  activeParameter?: number | null
 }
 
 export interface Signature {
   label: string
-  documentation?: string
+  documentation?: string | MarkupContent
   parameters?: SignatureParameter[]
+}
+export type SignatureInformation = Signature
+
+export type MarkupKind = "plaintext" | "markdown"
+
+export interface MarkupContent {
+  kind: MarkupKind
+  value: string
 }
 
 export interface SignatureParameter {
-  label: string
-  documentation?: string
+  label: string | [number, number]
+  documentation?: string | MarkupContent
 }
+export type ParameterInformation = SignatureParameter

--- a/types-packages/text-edit.d.ts
+++ b/types-packages/text-edit.d.ts
@@ -1,0 +1,8 @@
+import type { Range } from "atom"
+
+export interface TextEdit {
+  oldRange: Range
+  newText: string
+  /** If included, this will be used to verify that the edit still applies cleanly. */
+  oldText?: string
+}

--- a/types-packages/uri.d.ts
+++ b/types-packages/uri.d.ts
@@ -1,0 +1,1 @@
+export type IdeUri = string


### PR DESCRIPTION
I compared the types in atom-languageclient with the types we had here in atom-ide-base, and I added the missing ones here. 

The types will be removed from atom-languageclient once this PR is merged.
https://github.com/atom-community/atom-languageclient/pull/121

We no longer need to maintain the types in two places.
